### PR TITLE
Update docs

### DIFF
--- a/documentation/api-docs.adoc
+++ b/documentation/api-docs.adoc
@@ -360,7 +360,7 @@ Request Url
 ^^^^^^^^^^^
 
 ----
-https://api.get-map.org/apis/jobs/
+https://api.get-map.org/apis/jobs/{id}
 ----
 
 Return codes

--- a/documentation/code-snippets/file-request.php
+++ b/documentation/code-snippets/file-request.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'HTTP/Request2.php';
 
-define('BASE_URL', 'https://api.get-map.org/apis/v1/');
+define('BASE_URL', 'https://api.get-map.org/apis/');
 define('GPX_FILE', 'A1.gpx');
 
 $data = [];

--- a/documentation/code-snippets/parameters.php
+++ b/documentation/code-snippets/parameters.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'HTTP/Request2.php';
 
-define('BASE_URL', 'https://api.get-map.org/apis/v1/');
+define('BASE_URL', 'https://api.get-map.org/apis/');
 
 function api_call($url) 
 {

--- a/documentation/code-snippets/simple-request.php
+++ b/documentation/code-snippets/simple-request.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'HTTP/Request2.php';
 
-define('BASE_URL', 'https://api.get-map.org/apis/v1/');
+define('BASE_URL', 'https://api.get-map.org/apis/');
 
 $data = ['title'       => 'PHP Test',
          'bbox_bottom' => 52.00,

--- a/documentation/code-snippets/wait-for-result.php
+++ b/documentation/code-snippets/wait-for-result.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'HTTP/Request2.php';
 
-define('BASE_URL', 'https://api.get-map.org/apis/v1/');
+define('BASE_URL', 'https://api.get-map.org/apis/');
 
 function api_GET($url) 
 {


### PR DESCRIPTION
Changes:
1. Job result API needs the id as path-parameter: `https://api.get-map.org/apis/jobs/{id}`
2. In the docs the base URL `https://api.get-map.org/apis/` is used and not like in the snippets `https://api.get-map.org/apis/v1/`